### PR TITLE
fix: Ensure PDF compression is always applied

### DIFF
--- a/src/components/PdfCompressor.tsx
+++ b/src/components/PdfCompressor.tsx
@@ -52,6 +52,15 @@ const PdfCompressor = () => {
     }
   };
 
+  const handleCompressionLevelChange = (level: string) => {
+    setCompressionLevel(level);
+    if (level === 'high') {
+      setScaleFactor(0.75);
+    } else {
+      setScaleFactor(1);
+    }
+  };
+
   const handleCompression = async () => {
     if (!pdf) return;
     setIsCompressing(true);
@@ -66,7 +75,7 @@ const PdfCompressor = () => {
         });
       }
 
-      const compressedPdfBytes = await pdfDoc.save({ useObjectStreams: compressionLevel === 'high' });
+      const compressedPdfBytes = await pdfDoc.save({ useObjectStreams: true });
       const compressedPdfBlob = new Blob([compressedPdfBytes], { type: 'application/pdf' });
 
       setCompressedSize(compressedPdfBlob.size);
@@ -188,7 +197,7 @@ const PdfCompressor = () => {
                       name="compressionLevel"
                       value="standard"
                       checked={compressionLevel === 'standard'}
-                      onChange={() => setCompressionLevel('standard')}
+                      onChange={() => handleCompressionLevelChange('standard')}
                       className="form-radio h-4 w-4 text-blue-600"
                     />
                     <span className="text-sm text-gray-700 dark:text-gray-300">Standard</span>
@@ -199,7 +208,7 @@ const PdfCompressor = () => {
                       name="compressionLevel"
                       value="high"
                       checked={compressionLevel === 'high'}
-                      onChange={() => setCompressionLevel('high')}
+                      onChange={() => handleCompressionLevelChange('high')}
                       className="form-radio h-4 w-4 text-blue-600"
                     />
                     <span className="text-sm text-gray-700 dark:text-gray-300">High</span>


### PR DESCRIPTION
The PDF compressor was not applying compression when the "Standard"
level was selected because the `useObjectStreams` option was only
enabled for the "High" setting. This was misleading and resulted in
larger-than-expected file sizes.

This commit fixes the issue by ensuring that `useObjectStreams: true` is
always set when saving the PDF, regardless of the selected compression
level. This guarantees that compression is always applied.

To create a meaningful distinction between the "Standard" and "High"
compression levels, the "High" setting now also applies a default
scaling of 75% to the PDF. The "Standard" setting defaults to 100%
scaling. The user can still manually adjust the scaling factor.